### PR TITLE
feat: enhance game state handling for reconnection

### DIFF
--- a/contexts/RoomContext.tsx
+++ b/contexts/RoomContext.tsx
@@ -53,6 +53,10 @@ export function RoomProvider({ children, roomCode }: RoomProviderProps) {
   const [isInGame, setIsInGame] = useState(false)
 
   const sequenceManagerRef = useRef<SequenceManager>(createSequenceManager())
+  // Ref for userId to avoid stale closure in handleGameMessage.
+  // On reconnect, handleConnected sets this synchronously before game_state arrives,
+  // while React state (userId) won't update until the next render.
+  const userIdRef = useRef<string | null>(null)
 
   // Reset game store when entering a new room to clear stale state (e.g. victory screen)
   useEffect(() => {
@@ -62,14 +66,20 @@ export function RoomProvider({ children, roomCode }: RoomProviderProps) {
   const handleConnected = useCallback((payload: ConnectedPayload) => {
     setRoom(payload.room)
     setUserId(payload.user_id)
+    userIdRef.current = payload.user_id
     // Initialize game store with player ID
     useGameStore.getState().setMyPlayerId(payload.user_id)
+    // If reconnecting to a room that's already in game, transition to game UI
+    // (the server will also auto-push a game_state message with full state)
+    if (payload.room.status === 'in_game') {
+      setIsInGame(true)
+    }
   }, [])
 
   const handleRoomUpdated = useCallback((updatedRoom: RoomSnapshot) => {
     setRoom(updatedRoom)
-    // Check if game has started
-    if (updatedRoom.status === 'in_progress') {
+    // Check if game has started (backend room status is 'in_game')
+    if (updatedRoom.status === 'in_game') {
       setIsInGame(true)
     }
   }, [])
@@ -86,16 +96,21 @@ export function RoomProvider({ children, roomCode }: RoomProviderProps) {
   }, [])
 
   const handleGameMessage = useCallback((message: GameMessage) => {
+    // Read userId from ref (set synchronously in handleConnected) to avoid
+    // stale closure — React state may not have updated yet when server
+    // sends game_state immediately after authenticated.
+    const currentUserId = userIdRef.current
+
     switch (message.type) {
       // Host receives game_started with full game state
       case 'game_started': {
         const payload = message.payload as { game_state: GameState; events: GameEvent[] }
-        if (!payload || !userId) return
+        if (!payload || !currentUserId) return
 
         // Apply full game state
         if (payload.game_state) {
           sequenceManagerRef.current.reset(payload.game_state.event_seq - 1)
-          applyGameState(payload.game_state, userId)
+          applyGameState(payload.game_state, currentUserId)
         }
 
         // Process initial events
@@ -130,15 +145,15 @@ export function RoomProvider({ children, roomCode }: RoomProviderProps) {
       }
 
       case 'game_state': {
-        const payload = message.payload as { state: GameState }
-        const state = payload?.state
-        if (!state || !userId) return
+        const payload = message.payload as { game_state: GameState }
+        const state = payload?.game_state
+        if (!state || !currentUserId) return
 
         // Reset sequence manager to match server state
         sequenceManagerRef.current.reset(state.event_seq - 1)
 
         // Apply full state
-        applyGameState(state, userId)
+        applyGameState(state, currentUserId)
 
         // Set in game if game is in progress
         if (state.phase === 'in_progress') {
@@ -156,7 +171,7 @@ export function RoomProvider({ children, roomCode }: RoomProviderProps) {
         break
       }
     }
-  }, [userId])
+  }, [])
 
   const {
     isConnected,

--- a/contexts/RoomContext.tsx
+++ b/contexts/RoomContext.tsx
@@ -145,8 +145,8 @@ export function RoomProvider({ children, roomCode }: RoomProviderProps) {
       }
 
       case 'game_state': {
-        const payload = message.payload as { game_state: GameState }
-        const state = payload?.game_state
+        const payload = message.payload as { state: GameState }
+        const state = payload?.state
         if (!state || !currentUserId) return
 
         // Reset sequence manager to match server state

--- a/hooks/useRoomWebSocket.ts
+++ b/hooks/useRoomWebSocket.ts
@@ -326,16 +326,18 @@ export function useRoomWebSocket({
   // Retry connection when accessToken becomes available after initial mount
   // (handles page refresh where AuthContext loads session asynchronously)
   useEffect(() => {
-    if (
-      accessToken &&
-      !wsRef.current &&
-      !isConnected &&
-      !isConnecting
-    ) {
+    const ws = wsRef.current
+
+    const socketInactive =
+      !ws ||
+      ws.readyState === WebSocket.CLOSED ||
+      ws.readyState === WebSocket.CLOSING
+
+    if (accessToken && socketInactive && !isConnected && !isConnecting) {
       shouldReconnectRef.current = true
       connectRef.current()
     }
-  }, [accessToken, isConnected, isConnecting])
+  }, [accessToken])
 
   return {
     isConnected,

--- a/hooks/useRoomWebSocket.ts
+++ b/hooks/useRoomWebSocket.ts
@@ -322,6 +322,20 @@ export function useRoomWebSocket({
     }
   }, [disconnect])
 
+  // Retry connection when accessToken becomes available after initial mount
+  // (handles page refresh where AuthContext loads session asynchronously)
+  useEffect(() => {
+    if (
+      accessToken &&
+      !wsRef.current &&
+      !isConnected &&
+      !isConnecting
+    ) {
+      shouldReconnectRef.current = true
+      connectRef.current()
+    }
+  }, [accessToken, isConnected, isConnecting])
+
   return {
     isConnected,
     isConnecting,

--- a/hooks/useRoomWebSocket.ts
+++ b/hooks/useRoomWebSocket.ts
@@ -231,6 +231,7 @@ export function useRoomWebSocket({
       }
 
       ws.onclose = (event) => {
+        wsRef.current = null
         setIsConnected(false)
         setIsConnecting(false)
         clearTimers()

--- a/lib/game/eventProcessor.ts
+++ b/lib/game/eventProcessor.ts
@@ -30,6 +30,18 @@ type EventHandler<T extends GameEvent = GameEvent> = (
   store: GameStore
 ) => void
 
+// Generate all valid move IDs for a stack, including suffix-based splits.
+// e.g. "stack_1_2_3" → ["stack_1_2_3", "stack_2_3", "stack_3"]
+function generateSplitMoveIds(stackId: string): string[] {
+  const parts = stackId.replace('stack_', '').split('_')
+  if (parts.length <= 1) return [stackId]
+  const ids: string[] = []
+  for (let i = 0; i < parts.length; i++) {
+    ids.push('stack_' + parts.slice(i).join('_'))
+  }
+  return ids
+}
+
 // Generate unique animation ID
 let animationIdCounter = 0
 function generateAnimationId(): string {
@@ -326,6 +338,15 @@ export function applyGameState(
 ): void {
   const store = useGameStore.getState()
 
+  // Clear all interactive UI state before repopulating — prevents stale
+  // highlights / modals from a previous current_event persisting across reconnects.
+  store.setAvailableMoves([])
+  store.setSelectedRoll(null)
+  store.setCaptureOptions([])
+  store.clearHighlightedTokens()   // also clears selectedStackId
+  store.setShowMoveChoiceModal(false)
+  store.setShowCaptureChoiceModal(false)
+
   store.initializeFromGameState(
     {
       phase: state.phase,
@@ -350,12 +371,14 @@ export function applyGameState(
       // Reconstruct available_moves from Turn data.
       // Each unique roll maps to all legal stacks — the server validates
       // the actual legality, so overly-broad options are safe.
+      // Generate suffix split IDs for each stack so split move options
+      // are available after reconnect (e.g. stack_1_2_3 → [stack_1_2_3, stack_2_3, stack_3]).
       const uniqueRolls = [...new Set(turn.rolls_to_allocate)]
       const availableMoves: RollMoveGroup[] = uniqueRolls.map(roll => ({
         roll,
         move_groups: turn.legal_moves.map(stackId => ({
           stack_id: stackId,
-          moves: [stackId],
+          moves: generateSplitMoveIds(stackId),
         })),
       }))
       store.setAvailableMoves(availableMoves)

--- a/lib/game/eventProcessor.ts
+++ b/lib/game/eventProcessor.ts
@@ -359,10 +359,12 @@ export function applyGameState(
     myPlayerId
   )
 
-  if (state.current_turn) {
-    store.setCurrentTurn(state.current_turn)
-    store.setCurrentEvent(state.current_event)
+  // Always synchronize turn/event state, even when there is no active turn,
+  // so stale values from a previous session don't persist.
+  store.setCurrentTurn(state.current_turn)
+  store.setCurrentEvent(state.current_event)
 
+  if (state.current_turn) {
     const turn = state.current_turn
     const isMyTurn = turn.player_id === myPlayerId
 

--- a/lib/game/eventProcessor.ts
+++ b/lib/game/eventProcessor.ts
@@ -18,6 +18,7 @@ import type {
   AnimationType,
   CaptureOption,
   HighlightedStack,
+  RollMoveGroup,
   GameState,
 } from '@/types/game'
 import { ANIMATION_DURATIONS } from './constants'
@@ -314,7 +315,10 @@ export function processEvents(events: GameEvent[]): void {
 }
 
 /**
- * Apply a full game state (for reconnection)
+ * Apply a full game state (for reconnection).
+ * Reconstructs interactive UI state (highlights, available moves) from
+ * the Turn snapshot since the server's GameState doesn't include the
+ * structured available_moves from awaiting_choice events.
  */
 export function applyGameState(
   state: GameState,
@@ -337,5 +341,51 @@ export function applyGameState(
   if (state.current_turn) {
     store.setCurrentTurn(state.current_turn)
     store.setCurrentEvent(state.current_event)
+
+    const turn = state.current_turn
+    const isMyTurn = turn.player_id === myPlayerId
+
+    // Restore interactive state for player_choice (piece selection)
+    if (state.current_event === 'player_choice' && turn.legal_moves.length > 0) {
+      // Reconstruct available_moves from Turn data.
+      // Each unique roll maps to all legal stacks — the server validates
+      // the actual legality, so overly-broad options are safe.
+      const uniqueRolls = [...new Set(turn.rolls_to_allocate)]
+      const availableMoves: RollMoveGroup[] = uniqueRolls.map(roll => ({
+        roll,
+        move_groups: turn.legal_moves.map(stackId => ({
+          stack_id: stackId,
+          moves: [stackId],
+        })),
+      }))
+      store.setAvailableMoves(availableMoves)
+
+      if (isMyTurn) {
+        const highlighted: HighlightedStack[] = turn.legal_moves.map(stackId => ({
+          stackId,
+          playerId: turn.player_id,
+          type: 'selectable' as const,
+        }))
+        store.setHighlightedTokens(highlighted)
+      }
+    }
+
+    // Restore interactive state for capture_choice
+    if (state.current_event === 'capture_choice' && turn.pending_capture && isMyTurn) {
+      const pending = turn.pending_capture
+      const options: CaptureOption[] = pending.capturable_targets.map(target => {
+        const [playerId, stackId] = target.split(':')
+        const player = state.players.find(p => p.player_id === playerId)
+        const stack = player?.stacks.find(s => s.stack_id === stackId)
+        return {
+          target,
+          playerColor: player?.color ?? 'red',
+          stackId,
+          stackHeight: stack?.height ?? 1,
+        }
+      })
+      store.setCaptureOptions(options)
+      store.setShowCaptureChoiceModal(true)
+    }
   }
 }

--- a/lib/pixi/TokenRenderer.ts
+++ b/lib/pixi/TokenRenderer.ts
@@ -301,6 +301,9 @@ export class TokenRenderer {
       const isHighlighted = this.highlightedKeys.has(key)
       const isSelected = key === this.selectedKey
 
+      const wasActive = sprite.isHighlighted || sprite.isSelected
+      const isActive = isHighlighted || isSelected
+
       sprite.isHighlighted = isHighlighted
       sprite.isSelected = isSelected
 
@@ -313,6 +316,18 @@ export class TokenRenderer {
       }
 
       sprite.graphics.cursor = isHighlighted ? 'pointer' : 'default'
+
+      // Redraw at normal scale when transitioning out of highlight/selected state
+      // to clear the frozen pulse scale and glow outline
+      if (wasActive && !isActive) {
+        const colorConfig = PLAYER_COLORS[sprite.playerColor]
+        const cellSize = this.geometry.getCellSize()
+        const radius = cellSize * TOKEN_VISUAL.RADIUS_RATIO
+        this.drawToken(sprite.graphics, radius, colorConfig.primary, colorConfig.secondary)
+        if (!sprite.graphics.children.includes(sprite.badge)) {
+          sprite.graphics.addChild(sprite.badge)
+        }
+      }
     }
   }
 


### PR DESCRIPTION
This pull request improves the reliability of game state restoration and reconnection handling in the multiplayer room context, particularly addressing issues with stale user IDs and restoring interactive UI state after reconnects. It also ensures that the WebSocket connection is retried when authentication becomes available, and reconstructs client-side interactive state from server snapshots.

**Reconnection and State Restoration Improvements:**

- Added a `userIdRef` to `RoomProvider` to avoid stale closures when handling game messages, ensuring the latest user ID is always used during reconnection and state restoration. (`contexts/RoomContext.tsx`) [[1]](diffhunk://#diff-f6b5d351181e1b59fec4df4cc02c070c94c2b25bb0c3c58590a6eba7a08ec506R56-R59) [[2]](diffhunk://#diff-f6b5d351181e1b59fec4df4cc02c070c94c2b25bb0c3c58590a6eba7a08ec506R69-R82) [[3]](diffhunk://#diff-f6b5d351181e1b59fec4df4cc02c070c94c2b25bb0c3c58590a6eba7a08ec506R99-R113) [[4]](diffhunk://#diff-f6b5d351181e1b59fec4df4cc02c070c94c2b25bb0c3c58590a6eba7a08ec506L133-R156) [[5]](diffhunk://#diff-f6b5d351181e1b59fec4df4cc02c070c94c2b25bb0c3c58590a6eba7a08ec506L159-R174)
- Enhanced the `applyGameState` function to reconstruct interactive UI state (such as available moves and highlights) from the current turn snapshot, since the server's `GameState` does not include all necessary structured data for the client UI. (`lib/game/eventProcessor.ts`) [[1]](diffhunk://#diff-cfad4ecf25884a949f93dc74e5749e3209b2f9272a06d85bda4e56587c81db06L317-R321) [[2]](diffhunk://#diff-cfad4ecf25884a949f93dc74e5749e3209b2f9272a06d85bda4e56587c81db06R344-R389) [[3]](diffhunk://#diff-cfad4ecf25884a949f93dc74e5749e3209b2f9272a06d85bda4e56587c81db06R21)

**WebSocket Connection Handling:**

- Improved WebSocket reconnection logic to retry connecting when the access token becomes available, addressing issues after page refreshes where authentication loads asynchronously. (`hooks/useRoomWebSocket.ts`)